### PR TITLE
Include content type json in all requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
 
-## 0.1.5 (Unreleased)
+## 0.1.5 (December 9 2021)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
+## 0.1.6 (Unreleased)
+
 
 ## 0.1.5 (December 9 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.1.6 (Unreleased)
 
+### Added
+
+* Include "Content-Type: application/json" in the header of all requests to the API.
 
 ## 0.1.5 (December 9 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.
 See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/).
 
+
 ## 0.1.5 (Unreleased)
+
+### Added
+
+* enableTls field for the database APIs.
 
 ## 0.1.4
 

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -65,6 +65,10 @@ func (c *HttpClient) connection(ctx context.Context, method, name, path string, 
 	}
 
 	request, err := http.NewRequestWithContext(ctx, method, u, body)
+
+	// The API expects this entry in the header in all requests.
+	request.Header.Set("Content-Type", "application/json")
+	
 	if err != nil {
 		return fmt.Errorf("failed to create request to %s: %w", name, err)
 	}

--- a/service/databases/model.go
+++ b/service/databases/model.go
@@ -33,6 +33,7 @@ type CreateDatabase struct {
 	Password                            *string                      `json:"password,omitempty"`
 	Alerts                              []*CreateAlert               `json:"alerts,omitempty"`
 	Modules                             []*CreateModule              `json:"modules,omitempty"`
+	EnableTls                           *bool                        `json:"enableTls,omitempty"`
 }
 
 func (o CreateDatabase) String() string {
@@ -123,6 +124,7 @@ type Security struct {
 	SSLClientAuthentication *bool     `json:"sslClientAuthentication,omitempty"`
 	SourceIPs               []*string `json:"sourceIps,omitempty"`
 	Password                *string   `json:"password,omitempty"`
+	EnableTls               *bool     `json:"enableTls,omitempty"`
 }
 
 func (o Security) String() string {
@@ -172,6 +174,7 @@ type UpdateDatabase struct {
 	ClientSSLCertificate                *string                      `json:"clientSslCertificate,omitempty"`
 	Password                            *string                      `json:"password,omitempty"`
 	Alerts                              []*UpdateAlert               `json:"alerts,omitempty"`
+	EnableTls                           *bool                        `json:"enableTls,omitempty"`
 }
 
 func (o UpdateDatabase) String() string {


### PR DESCRIPTION
This fixes the issue where the API is returning the following error:
```
  "message" : "Content type 'application/octet-stream' not supported",
```